### PR TITLE
change solace-iot-team to solace-labs & handle of repo renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-[![integration-test](https://github.com/solace-iot-team/ep-sdk/actions/workflows/integration-test.yml/badge.svg)](https://github.com/solace-iot-team/ep-sdk/actions/workflows/integration-test.yml)
-[![docs-test](https://github.com/solace-iot-team/ep-sdk/actions/workflows/docs-test.yml/badge.svg)](https://github.com/solace-iot-team/ep-sdk/actions/workflows/docs-test.yml)
-[![release](https://github.com/solace-iot-team/ep-sdk/actions/workflows/release.yml/badge.svg)](https://github.com/solace-iot-team/ep-sdk/actions/workflows/release.yml)
-[![release-docs](https://github.com/solace-iot-team/ep-sdk/actions/workflows/release-docs.yml/badge.svg)](https://github.com/solace-iot-team/ep-sdk/actions/workflows/release-docs.yml)
-[![Coverage Status](https://coveralls.io/repos/github/solace-iot-team/ep-sdk/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/solace-iot-team/ep-sdk?branch=main)
+[![integration-test](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/integration-test.yml/badge.svg)](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/integration-test.yml)
+[![docs-test](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/docs-test.yml/badge.svg)](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/docs-test.yml)
+[![release](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/release.yml/badge.svg)](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/release.yml)
+[![release-docs](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/release-docs.yml/badge.svg)](https://github.com/SolaceLabs/ep-sdk-typescript/actions/workflows/release-docs.yml)
+[![Coverage Status](https://coveralls.io/repos/github/solace-labs/ep-sdk/badge.svg?branch=main&kill_cache=1)](https://coveralls.io/github/solace-labs/ep-sdk?branch=main)
 
 
 # Solace Event Portal SDK
 
-[Issues & Feature Requests](https://github.com/solace-iot-team/ep-sdk/issues) |
-[Discussions](https://github.com/solace-iot-team/ep-sdk/discussions) |
+[Issues & Feature Requests](https://github.com/SolaceLabs/ep-sdk-typescript/issues) |
+[Discussions](https://github.com/SolaceLabs/ep-sdk-typescript/discussions) |
 [Release Notes](./ReleaseNotes.md) |
-[Documentation](https://solace-iot-team.github.io/ep-sdk/)
+[Documentation](https://solace-labs.github.io/ep-sdk/)
 
 
 The SDK comprises of:

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -62,7 +62,7 @@ Solace Event Portal SDK.
   - switched to packaged ep-openapi-node and removed from repo
 
 ## Version 0.2.9-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **Enhancements:**
 - **EpSdkVersionTaskStrategyValidationError**
@@ -70,7 +70,7 @@ Solace Event Portal SDK.
 
 
 ## Version 0.2.8-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **Enhancements:**
 - **EpSdkVersionTasks**
@@ -79,13 +79,13 @@ Solace Event Portal SDK.
     - aborts with `EpSdkVersionTaskStrategyValidationError` if `versionString` is not greater than existing version
 
 ## Version 0.2.7-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **Fixes:**
 - fixed spelling mistakes in method names
 
 ## Version 0.2.6-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **New Features:**
 - **Services**
@@ -96,7 +96,7 @@ Solace Event Portal SDK.
   - added: **EpSdkEventApiVersionTask**
 
 ## Version 0.2.5-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **New Features:**
 - **Services**
@@ -108,7 +108,7 @@ Solace Event Portal SDK.
 
 
 ## Version 0.2.4-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **New Features:**
 - **Services**
@@ -119,7 +119,7 @@ Solace Event Portal SDK.
   - added: **EpSdkSchemaVersionTask**
 
 ## Version 0.2.3-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **New Features:**
 - **Services**
@@ -130,13 +130,13 @@ Solace Event Portal SDK.
   - added: **EpSdkEnumVersionTask**
 
 ## Version 0.2.2-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 - **EpTask: transaction log**
   - added object keys to transaction log
 
 ## Version 0.2.1-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **New Features:**
 - **Tasks**
@@ -148,7 +148,7 @@ Solace Event Portal SDK.
 
 
 ## Version 0.2.0-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **New Features:**
 - **Services**
@@ -162,7 +162,7 @@ Solace Event Portal SDK.
 
 
 ## Version 0.1.0-alpha
-  * [Solace Event Portal OpenAPI](https://github.com/solace-iot-team/ep-sdk/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
+  * [Solace Event Portal OpenAPI](https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/resources/sep-openapi-spec.2.0.0-ea.json): '2.0.0-ea'
 
 **Initial Alpha Release.**
 

--- a/docs/source/ep-openapi-content/overview.rst
+++ b/docs/source/ep-openapi-content/overview.rst
@@ -18,7 +18,7 @@ Using helper `EpSdkClient`:
 
 .. code-block:: typescript
 
-  import { OpenAPI } from "@solace-iot-team/ep-openapi-node";
+  import { OpenAPI } from "@solace-labs/ep-openapi-node";
 
   EpSdkClient.initialize({
     globalOpenAPI: OpenAPI,
@@ -29,7 +29,7 @@ Using `OpenAPI` directly:
 
 .. code-block:: typescript
 
-  import { OpenAPI } from "@solace-iot-team/ep-openapi-node";
+  import { OpenAPI } from "@solace-labs/ep-openapi-node";
 
   OpenAPI.BASE = baseUrl; // to set it to other than default as in the spec, otherwise leave as is
   OpenAPI.WITH_CREDENTIALS = true;

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,7 +17,7 @@ Repos & Links
 
 
 .. _Solace Event Portal SDK:
-  https://github.com/solace-iot-team/ep-sdk/tree/main/ep-sdk
+  https://github.com/SolaceLabs/ep-sdk-typescript/tree/main/ep-sdk
 
 .. _Release Notes:
-  https://github.com/solace-iot-team/ep-sdk/blob/main/ReleaseNotes.md
+  https://github.com/SolaceLabs/ep-sdk-typescript/blob/main/ReleaseNotes.md

--- a/ep-sdk/README.md
+++ b/ep-sdk/README.md
@@ -1,9 +1,9 @@
 # Solace Event Portal SDK
 
 ```bash
-npm install @solace-iot-team/ep-sdk
+npm install @solace-labs/ep-sdk
 ```
 
-[See Documentation for more Details](https://solace-iot-team.github.io/ep-sdk/).
+[See Documentation for more Details](https://solace-labs.github.io/ep-sdk/).
 
 ---

--- a/ep-sdk/package-lock.json
+++ b/ep-sdk/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@solace-iot-team/ep-sdk",
+  "name": "@solace-labs/ep-sdk",
   "version": "0.8.0-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@solace-iot-team/ep-sdk",
+      "name": "@solace-labs/ep-sdk",
       "version": "0.8.0-alpha",
       "license": "MIT",
       "dependencies": {

--- a/ep-sdk/package.json
+++ b/ep-sdk/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "@solace-iot-team/ep-sdk",
+  "name": "@solace-labs/ep-sdk",
   "version": "0.8.0-alpha",
   "description": "Solace Event Portal SDK",
   "type": "commonjs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "homepage": "https://github.com/solace-iot-team/ep-sdk",
+  "homepage": "https://github.com/SolaceLabs/ep-sdk-typescript",
   "repository": {
     "type": "git",
-    "url": "https://github.com/solace-iot-team/ep-sdk.git"
+    "url": "https://github.com/SolaceLabs/ep-sdk-typescript.git"
   },
   "keywords": [
     "api management",
@@ -25,7 +25,7 @@
   ],
   "license": "APACHE-2.0",
   "bugs": {
-    "url": "https://github.com/solace-iot-team/ep-sdk/issues"
+    "url": "https://github.com/SolaceLabs/ep-sdk-typescript/issues"
   },
   "scripts": {
     "compile:examples": "tsc --project examples/tsconfig.json",


### PR DESCRIPTION
This will likely initially break the github pages, coverall links, etc so probably take a few minutes to review the changes :) 